### PR TITLE
Ignore Shellcheck directives

### DIFF
--- a/tomdoc.sh
+++ b/tomdoc.sh
@@ -210,8 +210,11 @@ parse_tomdoc() {
     while read -r line; do
         case "$line" in
         '#'|'# '*)
-            doc="$doc$line
+            # Ignore Shellcheck directives
+            if ! [[ $line =~ ^"#"([[:space:]]+)?"shellcheck" ]]; then
+                doc="$doc$line
 "
+            fi
             ;;
         *)
             test -n "$line" -a -n "$doc" && {


### PR DESCRIPTION
Hi,

I use Shellcheck (https://github.com/koalaman/shellcheck) to analyse my shell scripts and sometimes it's necessary to ignore warnings (https://github.com/koalaman/shellcheck/wiki/Ignore). Ignore a shellcheck warning require to add a comment then tomdoc.sh generate this directive like documentation.

**example.sh**

```
#/bin/bash

hexToAscii() {
  # shellcheck disable=SC2034
  var="hello world"
}

```

Generate doc

```
`var`
-----

shellcheck disable=SC2034
```

I just add a condition in tomdoc.sh to ignore lines begin with **# shellcheck**
